### PR TITLE
Multi-language support & lazy command line & clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 .vscode
 .kattisrc
-.exe
+*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode
 .kattisrc
+.exe

--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,3 @@
+{
+    "brace_style": "end-expand,preserve-inline"
+}

--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,3 +1,0 @@
-{
-    "brace_style": "end-expand,preserve-inline"
-}

--- a/Accepted/.gitignore
+++ b/Accepted/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/README.md
+++ b/README.md
@@ -4,16 +4,71 @@
 A helper suite to make it easier to run, test, and submit problems to Kattis
 
 ### Requirements
-python 3, nodejs,
+[python 3](https://www.python.org/)
+[nodejs](https://nodejs.org/en/download/)
 .kattisrc (download from https://open.kattis.com/download/kattisrc and add it to the project root)
 
 ### Definitions
 **problem**: Kattis Problem ID
 
 ### Commands
-**npm run init _\<problem\>_** fetches samples for the given problem and creates a new code file for that problem by copying **defaultFileTemplate**.
-Replace **defaultFileTemplate.\<your language\>** as you please.
-#### Supported languages for defaultFileTemplate:
+#### Initialize
+```
+npm run init <problem> <language>
+```
+fetches samples for the given problem and creates a new code file for that problem by copying **_\<your language\>__template._\<language extension\>_** file.
+The problem and language is saved in a local .json file for further use
+#### Run tests
+```
+npm run test [<problem>] [<language>]
+```
+Runs the sample tests for the given problem. The problem and language here is **optional**, if nothing is given the saved problem and language from the initial stage will be used.
+#### Submit
+```
+npm run submit [<problem>] [<language>]
+```
+Submits the given problem to Kattis and periodically polls the test results of the submission. The problem and language here is **optional**, if nothing is given the saved problem and language from the initial stage will be used.
+
+### Template
+The template files are how the initial file will look like with the given language.
+These files are located at ```./utils/templates```. Simply modify these to your liking.
+
+
+### Add language
+* Open up ```./languages.json```
+* It should look something like this
+```
+{
+    "c": {
+        "fileExt": "c",
+        "command": "./problem.exe",
+        "compiler": {
+            "command": "gcc",
+            "args": [
+                "-g",
+                "${problemFile}",
+                "-o",
+                "${workspaceFolder}/problem.exe"
+            ]
+        }
+    },
+    "node": {
+        "fileExt": "js",
+        "command": "node",
+        "args": [
+            "${problemFile}"
+        ]
+    }
+}
+```
+Simply extend this file by adding a new language with the the given properties where ```"compiler"``` property is optional.
+#### Add template
+When a language has been added you need to add the template for the given Language.
+* Go to ```./utils/templates```
+* Create a new file ```<language>_template.<fileExt>```
+* Open up the created file and modify it to your liking
+
+#### Supported languages:
     '.c': 'C',
     '.c#': 'C#',
     '.c++': 'C++',
@@ -32,7 +87,3 @@ Replace **defaultFileTemplate.\<your language\>** as you please.
     '.pl': 'Prolog',
     '.py': 'Python',
     '.rb': 'Ruby'
-
-**npm run test _\<problem\>_** runs the sample tests for the given problem
-
-**npm run submit _\<problem\>_** submits the given problem to kattis and periodically polls the test results of the submission

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 A helper suite to make it easier to run, test, and submit problems to Kattis
 
 ### Requirements
-[python 3](https://www.python.org/)__
-[nodejs](https://nodejs.org/en/download/)__
-.kattisrc (download from https://open.kattis.com/download/kattisrc and add it to the project root)
+* [python 3](https://www.python.org/)
+* [nodejs](https://nodejs.org/en/download/)
+* .kattisrc (download from https://open.kattis.com/download/kattisrc and add it to the project root)
 
 ### Definitions
 **problem**: Kattis Problem ID

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 A helper suite to make it easier to run, test, and submit problems to Kattis
 
 ### Requirements
-[python 3](https://www.python.org/)
-[nodejs](https://nodejs.org/en/download/)
+[python 3](https://www.python.org/)__
+[nodejs](https://nodejs.org/en/download/)__
 .kattisrc (download from https://open.kattis.com/download/kattisrc and add it to the project root)
 
 ### Definitions

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ These files are located at ```./utils/templates```. Simply modify these to your 
 ### Add language
 * Open up ```./languages.json```
 * It should look something like this
-```
+```javascript
 {
     "c": {
         "fileExt": "c",

--- a/languages.json
+++ b/languages.json
@@ -1,0 +1,22 @@
+{
+    "c": {
+        "fileExt": "c",
+        "command": "./problem.exe",
+        "compiler": {
+            "command": "gcc",
+            "args": [
+                "-g",
+                "${problemFile}",
+                "-o",
+                "${workspaceFolder}/problem.exe"
+            ]
+        }
+    },
+    "node": {
+        "fileExt": "js",
+        "command": "node",
+        "args": [
+            "${problemFile}"
+        ]
+    }
+}

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -1,0 +1,1 @@
+storage.json

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,20 +1,30 @@
+const path = require('path')
+
 const STATUS = {
-	5: 'Running',
-	14: 'Wrong answer',
-	16: 'Success',
-	RUNNING: 5,
+    5: 'Running',
+    14: 'Wrong answer',
+    16: 'Success',
+    RUNNING: 5,
 }
 
 const TEST_STATUS = {
-	'Accepted': '✅',
-	ACCEPTED: '✅',
-	'Wrong Answer': '❌',
-	WRONG_ANSWER: '❌',
-	'not checked': '❔',
-	NOT_CHECKED: '❔',
+    'Accepted': '✅',
+    ACCEPTED: '✅',
+    'Wrong Answer': '❌',
+    WRONG_ANSWER: '❌',
+    'not checked': '❔',
+    NOT_CHECKED: '❔',
+}
+
+const PATHS = {
+    PROBLEMS: path.join(__dirname, '..', 'Problems'),
+    ACCEPTED: path.join(__dirname, '..', 'Accepted'),
+    TEMPLATES: path.join(__dirname, 'templates'),
+    SAMPLE_DATA: path.join(__dirname, '..', 'SampleData'),
 }
 
 module.exports = {
-	STATUS,
-	TEST_STATUS
+    STATUS,
+    TEST_STATUS,
+    PATHS
 }

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -14,6 +14,8 @@ const TEST_STATUS = {
     WRONG_ANSWER: '❌',
     'not checked': '❔',
     NOT_CHECKED: '❔',
+    RUN_TIME_ERROR: '⚠️',
+    'Run Time Error': '⚠️'
 }
 
 const PATHS = {

--- a/utils/getCookie.js
+++ b/utils/getCookie.js
@@ -7,7 +7,7 @@ const getCookie = async () => {
 
 	var output = ''
 	for await (const data of child.stdout) output = output + data.toString()
-    
+
 	const body = JSON.parse(output.split('\'').join('"'))
 	return `EduSiteCookie=${body.EduSiteCookie}; __cfduid=${body.__cfduid};`
 }

--- a/utils/init.js
+++ b/utils/init.js
@@ -1,15 +1,29 @@
-const getSampleData = require('./getSampleData')
 const fs = require('fs')
 const path = require('path')
-const DEFAULT_FILE_TEMPLATE_NAME = 'defaultFileTemplate'
 
-const problem = process.argv[2]
-const files = fs.readdirSync(__dirname)
-const template = files.find(x => x.startsWith(DEFAULT_FILE_TEMPLATE_NAME))
-const fileType = template.split('.')[1]
-const problemPath = path.join(__dirname, '..', 'Problems', `${problem}.${fileType}`)
-const templatePath = path.join(__dirname, template)
+const { PATHS } = require('./constants')
+const log = require('./log')
+const getSampleData = require('./getSampleData')
+const storage = require('./storage')
+const settings = require('./settings')
+
+const problem = settings.problem
+const problemExt = settings.fileExt
+const language = settings.language
+
+storage.store({
+    'language': language,
+    'problem': problem
+})
+
+const templateFileName = `${language}_template.${problemExt}`
+const templatePath = path.join(PATHS.TEMPLATES, templateFileName)
+if (!fs.existsSync(templatePath)) log.error(`Could not find ${templatePath}`)
+
+const problemPath = path.join(PATHS.PROBLEMS, `${problem}.${problemExt}`)
+if (!fs.existsSync(problemPath))
+    fs.copyFileSync(templatePath, problemPath)
+else
+    log.notice(`Problem \'${problem}\' already exists`);
 
 getSampleData(problem)
-
-if (!fs.existsSync(problemPath)) fs.copyFileSync(templatePath, problemPath)

--- a/utils/log.js
+++ b/utils/log.js
@@ -1,0 +1,28 @@
+const LOG_LEVELS = {
+    'error': '\x1b[31;4;1mError\x1b[0m',
+    'warn': '\x1b[33;4;1mWarning\x1b[0m',
+    'notice': '\x1b[32;4;1mNotice\x1b[0m'
+}
+
+const error = (msg) => {
+    log(msg, 'error')
+    process.exit(0)
+}
+
+const warn = (msg) => {
+    log(msg, 'warn')
+}
+
+const notice = (msg) => {
+    log(msg, 'notice')
+}
+
+const log = (msg, level = 'notice') => {
+    process.stdout.write(`${LOG_LEVELS[level]}: ${msg}\n`)
+}
+
+module.exports = {
+    error,
+    warn,
+    notice
+}

--- a/utils/parseList.js
+++ b/utils/parseList.js
@@ -1,0 +1,13 @@
+const parseList = (list, placeholders) => {
+    Object.keys(list).forEach(key => {
+        if (Array.isArray(list[key]) || typeof list[key] === 'object')
+            list[key] = parseList(list[key], placeholders)
+        else
+            list[key] = list[key].replace(/\${(\w+)}/g, function(__, key) {
+                return placeholders[key] || key
+            })
+    })
+    return list
+}
+
+module.exports = parseList

--- a/utils/settings.js
+++ b/utils/settings.js
@@ -1,0 +1,32 @@
+const log = require('./log')
+const storage = require('./storage')
+const languages = require('../languages.json')
+
+const MUST_HAVE_KEYS = [
+    'fileExt',
+    'command'
+]
+
+let settings = {}
+
+settings.problem = process.argv[2] || storage.get('problem')
+if (settings.problem == null)
+    log.error('Problem input not found')
+
+settings.language = process.argv[3] || storage.get('language')
+if (settings.language == null)
+    log.error('Language input not found')
+
+if (typeof languages[settings.language] === 'undefined')
+    log.error(`Selected language \'${lang}\' does not exist`)
+
+Object.keys(languages[settings.language]).forEach(key => {
+    settings[key] = languages[settings.language][key]
+})
+
+MUST_HAVE_KEYS.forEach(key => {
+    if (!settings.hasOwnProperty(key))
+        log.error(`Invalid syntax in \'languages.json\' at \'${settings.language}\' language, could not find \'${key}\' property`)
+})
+
+module.exports = settings

--- a/utils/storage.js
+++ b/utils/storage.js
@@ -1,0 +1,26 @@
+const fs = require('fs')
+
+store = (items) => {
+    Object.keys(items).forEach(key => {
+        items[key] = items[key]
+    });
+    const data = JSON.stringify(items)
+    fs.writeFileSync('./utils/storage.json', data)
+}
+
+get = (key) => {
+    if (typeof items[key] !== 'undefined')
+        return items[key]
+    return null
+}
+
+let items = {}
+try {
+    items = require('./storage.json')
+}
+catch (e) {}
+
+module.exports = {
+    store,
+    get
+}

--- a/utils/submitAndPoll.js
+++ b/utils/submitAndPoll.js
@@ -1,25 +1,54 @@
 const path = require('path')
 const { spawn } = require('child_process')
+const fs = require('fs')
+
+const { PATHS } = require('./constants')
 const poll = require('./testPoller')
+const settings = require('./settings')
+const log = require('./log')
 
-const submit = async problem => {
-	const submitPath = path.join(__dirname, 'submit.py')
-	const problemPath = path.join(__dirname, '..', 'Problems', `${problem}.js`)
-	const child = spawn('python', [`${submitPath}`, '-p', problem, '-f', `${problemPath}`])
+const submit = async (problem, problemExt) => {
+    const submitPath = path.join(__dirname, 'submit.py')
+    const problemPath = path.join(PATHS.PROBLEMS, `${problem}.${problemExt}`)
+    const child = spawn('python', [`${submitPath}`, '-p', problem, '-f', `${problemPath}`])
 
-	let output = ''
-	for await (const data of child.stdout) output += data.toString()
+    let output = ''
+    for await (const data of child.stdout) output += data.toString()
 
-	const submissionId = parseInt(output)
-	if (submissionId) console.log(`Successfully submitted problem ${problem} to Kattis.`)
+    const submissionId = parseInt(output)
+    if (submissionId) console.log(`Successfully submitted problem ${problem} to Kattis.`)
 
-	return submissionId
+    return submissionId
 }
 
 const run = async () => {
-	const problem = process.argv[2]
-	const submissionId = await submit(problem)
-	await poll(submissionId)
+    const problem = settings.problem
+    const problemExt = settings.fileExt
+
+    const problemPath = path.join(PATHS.PROBLEMS, `${problem}.${problemExt}`)
+    if (!fs.existsSync(problemPath)) {
+        log.warn(`Selected problem \'${problem}.${problemExt}\' does not exist`)
+        return
+    }
+
+    const submissionId = await submit(problem, problemExt)
+    const result = await poll(submissionId)
+    if (result.length == 0) {
+        log.error('Submission failed, something wrong happened...')
+        return
+    }
+    for (let index = 0; index < result.length; index++) {
+        if (result[index] != 'Accepted') {
+            log.notice('You did not pass, better luck next time')
+            return
+        }
+    }
+
+    const acceptedPath = path.join(PATHS.ACCEPTED, `${problem}.${problemExt}`)
+    fs.rename(problemPath, acceptedPath, err => {
+        if (err) log.error(err)
+        log.notice('Congratulations you passed! File successfuly moved to accepted folder')
+    })
 }
 
 run()

--- a/utils/templates/c_template.c
+++ b/utils/templates/c_template.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int main() {
+    int count;
+    scanf("%d", &count);
+
+    printf("");
+    return 0;
+}

--- a/utils/templates/node_template.js
+++ b/utils/templates/node_template.js
@@ -1,8 +1,9 @@
+
 const readline = require('readline')
 
 const rl = readline.createInterface({
-	input: process.stdin,
-	output: process.stdout
+    input: process.stdin,
+    output: process.stdout
 })
 
 
@@ -10,7 +11,7 @@ var input = []
 rl.on('line', (line) => input.push(line))
 
 rl.on('close', () => {
-	// Problem here
+    // Problem here
 
-	process.exit()
+    process.exit()
 })

--- a/utils/testHelper.js
+++ b/utils/testHelper.js
@@ -2,53 +2,92 @@ const path = require('path')
 const normalizeNewline = require('normalize-newline')
 const fs = require('fs')
 const { spawn } = require('child_process')
-const assert = require('assert')
-const { TEST_STATUS } = require('./constants')
+
+const { TEST_STATUS, PATHS } = require('./constants')
+const parseList = require('./parseList')
+const log = require('./log')
+const settings = require('./settings')
 
 const readSampleData = dir => {
-	const sampleData = {}
-	fs.readdirSync(dir).forEach(filename => {
-		const { name, ext } = path.parse(filename)
-		const filePath = path.resolve(dir, filename)
+    const sampleData = {}
+    fs.readdirSync(dir).forEach(filename => {
+        const { name, ext } = path.parse(filename)
+        const filePath = path.resolve(dir, filename)
 
-		const data = fs.readFileSync(filePath).toString()
-		if (!sampleData[name]) sampleData[name] = {}
+        const data = fs.readFileSync(filePath).toString()
+        if (!sampleData[name]) sampleData[name] = {}
 
-		sampleData[name][ext] = data
-	})
+        sampleData[name][ext] = data
+    })
 
-	return sampleData
+    return sampleData
 }
 
-const run = async () => {
-	const problem = process.argv[2]
-	const problemPath = path.join(__dirname, '..', 'Problems', `${problem}.js`)
-	const samplePath = path.join(__dirname, '..', 'SampleData', problem, '\\')
-	
-	// TODO: Check if we have sample data and fetch it if we don't...
-	const sampleData = readSampleData(samplePath)
+const runTests = async (command, args, sampleData) => {
+    let count = 0
+    const results = new Array(Object.keys(sampleData).length)
+    for (let index = 0; index < results.length; index++) results[index] = {}
 
-	let count = 0
-	const results = new Array(Object.keys(sampleData).length).fill(TEST_STATUS.NOT_CHECKED)
+    log.notice('Running tests...')
+    for (const key in sampleData) {
+        const result = results[count]
+        const testCase = sampleData[key]['.in']
+        const expectedOutput = sampleData[key]['.ans']
 
-	for (const key in sampleData) {
-		const testCase = sampleData[key]['.in']
-		const expectedOutput = sampleData[key]['.ans']
-		const child = spawn('node', [problemPath]) // TODO: replace hard coded node with other options...
-		child.stdin.end(testCase)
+        const child = spawn(command, args)
+        child.stdin.end(testCase)
 
-		let output = ''
-		for await (const data of child.stdout) output += data.toString()
+        let output = ''
+        for await (const data of child.stdout) output += data.toString()
 
-		assert.strictEqual(
-			normalizeNewline(output),
-			normalizeNewline(expectedOutput)
-		)
+        result['output'] = normalizeNewline(output)
+        result['expectedOutput'] = normalizeNewline(expectedOutput)
 
-		results[count++] = TEST_STATUS.ACCEPTED
-		const prettyOutput = results.map(x => `[ ${x}  ]`).join('')
-		console.log('\x1Bc', prettyOutput)
-	}
+        if (Object.is(result['output'], result['expectedOutput']))
+            result['status'] = TEST_STATUS.ACCEPTED
+        else
+            result['status'] = TEST_STATUS.WRONG_ANSWER
+        count++;
+    }
+    let prettyOutput = '\x1B[31m- actual \x1B[32m+ expected\x1B[0m\n'
+    results.forEach(r => {
+        prettyOutput += `[ ${r['status']}  ]: \x1B[31m- ${JSON.stringify(r['output'])}\n` +
+            `\t\x1B[32m+ ${JSON.stringify(r['expectedOutput'])}\x1B[0m\n`
+    })
+    process.stdout.write(prettyOutput)
 }
 
-run()
+const start = () => {
+    const problem = settings.problem
+    const problemExt = settings.fileExt
+
+    const problemFile = path.join(PATHS.PROBLEMS, `${problem}.${problemExt}`)
+    if (!fs.existsSync(problemFile)) {
+        log.warn(`Selected problem \'${problem}.${problemExt}\' does not exist`)
+        return
+    }
+    parseList(settings, { 'problemFile': problemFile, 'workspaceFolder': process.cwd() })
+
+    const samplePath = path.join(PATHS.SAMPLE_DATA, problem, '\\')
+    // TODO: Check if we have sample data and fetch it if we don't...
+    const sampleData = readSampleData(samplePath)
+    // Compile if 'compiler' property is set in language.json else just run...
+    if (settings.hasOwnProperty('compiler')) {
+        const compilerExec = spawn(settings.compiler['command'], settings.compiler['args'] || [])
+        compilerExec.stderr.on('data', (data) => {
+            console.log(data.toString())
+        })
+        compilerExec.on('close', (data) => {
+            if (data === 0) {
+                log.notice('Compiled successfuly')
+                runTests(settings.command, settings.args || [], sampleData)
+            }
+            else
+                log.error('Compile failed')
+        })
+    }
+    else
+        runTests(settings.command, settings.args || [], sampleData)
+}
+
+start()

--- a/utils/testPoller.js
+++ b/utils/testPoller.js
@@ -9,14 +9,14 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 const getSubmission = async (submissionId, cookie) =>
     fetch(`https://open.kattis.com/submissions/${submissionId}?only_submission_row`, { headers: { cookie: cookie } })
-    .then(res => res.json())
-    .then(json => {
-        var testComponent = json.component
-        var htmlTestCases = testComponent.split('Test case ').slice(1)
-        var testCases = htmlTestCases.map(x => x.split('">')[0].split(': ')[1])
+        .then(res => res.json())
+        .then(json => {
+            var testComponent = json.component
+            var htmlTestCases = testComponent.split('Test case ').slice(1)
+            var testCases = htmlTestCases.map(x => x.split('">')[0].split(': ')[1])
 
-        return { testCases, state: json.status_id }
-    })
+            return { testCases, state: json.status_id }
+        })
 
 const poll = async submissionId => {
     const cookie = await getCookie()

--- a/utils/testPoller.js
+++ b/utils/testPoller.js
@@ -1,31 +1,36 @@
 const fetch = require('node-fetch')
+const fs = require('fs')
+const path = require('path')
+
 const { TEST_STATUS, STATUS } = require('./constants')
 const getCookie = require('./getCookie')
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 const getSubmission = async (submissionId, cookie) =>
-	fetch(`https://open.kattis.com/submissions/${submissionId}?only_submission_row`, { headers: { cookie: cookie } })
-		.then(res => res.json())
-		.then(json => {
-			var testComponent = json.component
-			var htmlTestCases = testComponent.split('Test case ').slice(1)
-			var testCases = htmlTestCases.map(x => x.split('">')[0].split(': ')[1])
+    fetch(`https://open.kattis.com/submissions/${submissionId}?only_submission_row`, { headers: { cookie: cookie } })
+    .then(res => res.json())
+    .then(json => {
+        var testComponent = json.component
+        var htmlTestCases = testComponent.split('Test case ').slice(1)
+        var testCases = htmlTestCases.map(x => x.split('">')[0].split(': ')[1])
 
-			var status = testCases.map(x => `[ ${TEST_STATUS[x]}  ]`).join('')
-			return { status, state: json.status_id }
-		})
+        return { testCases, state: json.status_id }
+    })
 
 const poll = async submissionId => {
-	const cookie = await getCookie()
+    const cookie = await getCookie()
 
-	var prevState = STATUS.RUNNING
-	while (prevState === STATUS.RUNNING) {
-		const { status, state } = await getSubmission(submissionId, cookie)
-		console.log('\x1Bc', status)
-		prevState = state
-		await sleep(1000)
-	}
+    var prevState = STATUS.RUNNING
+    var submission = {}
+    while (prevState === STATUS.RUNNING) {
+        submission = await getSubmission(submissionId, cookie)
+        const status = submission.testCases.map(x => `[ ${TEST_STATUS[x]}  ]`).join('')
+        console.log('\x1Bc', status)
+        prevState = submission.state
+        await sleep(1000)
+    }
+    return submission.testCases
 }
 
 module.exports = poll


### PR DESCRIPTION
### Multi-language support
Added multi-language support which makes it easy to change language on the fly and add whatever language you want. To add a new language simply configure the languages.json file and add a corresponding template file.

### Lazy command line
Added a storage system to save command argument so you can type what language you want once and which problem you have once.
Example:
```
npm run init problem1 c
npm run test
npm run submit

npm run init problem2
npm run test
npm run submit
```
These can be overwritten as well if you want to test or submit some other problem file or w.e.
Example:
```
npm run init problem1 node
npm run test problem2 c
```
But the problem and language will only be saved in the `init` command

### Testing
Remade how testing shows on screen. Removed the assertion and made a custom output which in my opinion looks neat.
![code_2019-02-02_23-21-13](https://user-images.githubusercontent.com/17483229/52169977-4d9cf400-2741-11e9-95da-8b181b5c8c35.png)


### Logging changes
Added some error handling instead of relying on crashes, it now describes what's wrong to the user instead of showing stack traces.

### Clean up
Cleaned up some files to remove repeated code etc.

### Others
The settings.js file now handles the input, storage loading and loading the language.json file.
Added 'Run time error' to test cases with a new icon since that was apparently a thing...